### PR TITLE
Update ngprogress-lite.js

### DIFF
--- a/ngprogress-lite.js
+++ b/ngprogress-lite.js
@@ -19,6 +19,8 @@
 			trickleSpeed: 500,
 			template: '<div class="ngProgressLite"><div class="ngProgressLiteBar"><div class="ngProgressLiteBarShadow"></div></div></div>'
 		};
+		
+		var stopping = false;
 
 		this.$get = ['$document', function ($document) {
 			var $body = $document.find('body');
@@ -74,11 +76,14 @@
 					num = privateMethods.clamp(num, settings.minimum, 1);
 					status = (num === 1 ? null : num);
 
-					setTimeout(function () {
-						$progress.children().eq(0).css(privateMethods.positioning(num, settings.speed, settings.ease));
-					}, 100);
+					if(!stopping) {
+						setTimeout(function () {
+							$progress.children().eq(0).css(privateMethods.positioning(num, settings.speed, settings.ease));
+						}, 100);
+					}
 
 					if (num === 1) {
+						stopping = true;
 						setTimeout(function () {
 							$progress.css({ 'transition': 'all ' + settings.speed + 'ms linear', 'opacity': 0 });
 							setTimeout(function () {


### PR DESCRIPTION
When using it for asynchronous chained calls, there's a case when calling done() multiple times (for instance start(),start(),done(),done())

This resulted in progressbar hiding instead of moving to the end. Added check for this.
